### PR TITLE
Added preprocessor macros and updated device instance for ReadProperty

### DIFF
--- a/BACnetClientExample/BACnetClientExample.cpp
+++ b/BACnetClientExample/BACnetClientExample.cpp
@@ -61,7 +61,7 @@ uint8_t invokeId;
 
 // Constants
 // =======================================
-const std::string APPLICATION_VERSION = "0.0.8";  // See CHANGELOG.md for a full list of changes.
+const std::string APPLICATION_VERSION = "0.0.9";  // See CHANGELOG.md for a full list of changes.
 const uint32_t MAX_XML_RENDER_BUFFER_LENGTH = 1024 * 20;
 
 // Settings 
@@ -365,7 +365,7 @@ void ExampleReadProperty() {
 	fpBuildReadProperty(CASBACnetStackExampleConstants::OBJECT_TYPE_BINARY_INPUT, 3, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_OBJECT_NAME, false, 0);
 	fpBuildReadProperty(CASBACnetStackExampleConstants::OBJECT_TYPE_BINARY_OUTPUT, 4, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_OBJECT_NAME, false, 0);
 	fpBuildReadProperty(CASBACnetStackExampleConstants::OBJECT_TYPE_BINARY_VALUE, 5, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_OBJECT_NAME, false, 0);
-	fpBuildReadProperty(CASBACnetStackExampleConstants::OBJECT_TYPE_DEVICE, 8, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_OBJECT_NAME, false, 0);
+	fpBuildReadProperty(CASBACnetStackExampleConstants::OBJECT_TYPE_DEVICE, 389999, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_OBJECT_NAME, false, 0);
 	fpBuildReadProperty(CASBACnetStackExampleConstants::OBJECT_TYPE_MULTI_STATE_INPUT, 13, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_OBJECT_NAME, false, 0);
 	fpBuildReadProperty(CASBACnetStackExampleConstants::OBJECT_TYPE_MULTI_STATE_OUTPUT, 14, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_OBJECT_NAME, false, 0);
 	fpBuildReadProperty(CASBACnetStackExampleConstants::OBJECT_TYPE_MULTI_STATE_VALUE, 19, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_OBJECT_NAME, false, 0);

--- a/BACnetClientExample/BACnetClientExample.vcxproj
+++ b/BACnetClientExample/BACnetClientExample.vcxproj
@@ -96,7 +96,12 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_DEBUG;ENABLE_DATA_LINK_LAYER_IPV4</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_DEBUG;ENABLE_DATA_LINK_LAYER_IPV4;ENABLE_STRING_LITERALS
+;ENABLE_DECODE_AS_JSON
+;ENABLE_DECODE_AS_XML
+;ENABLE_BACNET_API_DEBUG_LOGGING
+;ENABLE_ALL_OBJECT_TYPES
+;ENABLE_ALL_BIBBS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\cas-common\source;$(SolutionDir)..\submodules\cas-bacnet-stack\source;$(SolutionDir)..\submodules\cas-bacnet-stack\adapters\cpp;$(SolutionDir)..\bin\;;$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\xml2json\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -114,7 +119,12 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_DEBUG;ENABLE_DATA_LINK_LAYER_IPV4</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_DEBUG;ENABLE_DATA_LINK_LAYER_IPV4;ENABLE_STRING_LITERALS
+;ENABLE_DECODE_AS_JSON
+;ENABLE_DECODE_AS_XML
+;ENABLE_BACNET_API_DEBUG_LOGGING
+;ENABLE_ALL_OBJECT_TYPES
+;ENABLE_ALL_BIBBS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\cas-common\source;$(SolutionDir)..\submodules\cas-bacnet-stack\source;$(SolutionDir)..\submodules\cas-bacnet-stack\adapters\cpp;$(SolutionDir)..\bin\;;$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\xml2json\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -134,7 +144,12 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;CAS_BACNET_STACK_LIB_TYPE_LIB;ENABLE_DATA_LINK_LAYER_IPV4</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;CAS_BACNET_STACK_LIB_TYPE_LIB;ENABLE_DATA_LINK_LAYER_IPV4;ENABLE_STRING_LITERALS
+;ENABLE_DECODE_AS_JSON
+;ENABLE_DECODE_AS_XML
+;ENABLE_BACNET_API_DEBUG_LOGGING
+;ENABLE_ALL_OBJECT_TYPES
+;ENABLE_ALL_BIBBS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\cas-common\source;$(SolutionDir)..\submodules\cas-bacnet-stack\source;$(SolutionDir)..\submodules\cas-bacnet-stack\adapters\cpp;$(SolutionDir)..\bin\;;$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\xml2json\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -156,7 +171,12 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;CAS_BACNET_STACK_LIB_TYPE_LIB;ENABLE_DATA_LINK_LAYER_IPV4</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;CAS_BACNET_STACK_LIB_TYPE_LIB;ENABLE_DATA_LINK_LAYER_IPV4;ENABLE_STRING_LITERALS
+;ENABLE_DECODE_AS_JSON
+;ENABLE_DECODE_AS_XML
+;ENABLE_BACNET_API_DEBUG_LOGGING
+;ENABLE_ALL_OBJECT_TYPES
+;ENABLE_ALL_BIBBS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\xml2json\include;$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\cas-common\source;$(SolutionDir)..\submodules\cas-bacnet-stack\source;$(SolutionDir)..\submodules\cas-bacnet-stack\adapters\cpp;$(SolutionDir)..\bin\;$(SolutionDir)..\submodules\cas-bacnet-stack\submodules\xml2json\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 0.0.x
 
+### 0.0.9 (2023-Oct-12)
+
+- Updated preprocessor macro to include ENABLE_STRING_LITERALS, ENABLE_DECODE_AS_JSON, ENABLE_DECODE_AS_XML, ENABLE_BACNET_API_DEBUG_LOGGING, ENABLE_ALL_OBJECT_TYPES, ENABLE_ALL_BIBBS
+- Updated ReadProperty to read for device instance 389999, which is the instance for the device programmed in the BACnetServerExampleCPP project
+- Tested using BACnetStack version 4.1.19.0
+
 ### 0.0.8 (2023-Sep-29)
 
 - Updated preprocessor macro to include ENABLE_DATA_LINK_LAYER_IPV4


### PR DESCRIPTION
- Updated preprocessor macro to include ENABLE_STRING_LITERALS, ENABLE_DECODE_AS_JSON, ENABLE_DECODE_AS_XML, ENABLE_BACNET_API_DEBUG_LOGGING, ENABLE_ALL_OBJECT_TYPES, ENABLE_ALL_BIBBS 
- Updated ReadProperty to read for device instance 389999, which is the instance for the device programmed in the BACnetServerExampleCPP project